### PR TITLE
Update ASU DIR Utilities package to match other ASU modules

### DIFF
--- a/asu_dir_utilities/asu_dir_utilities.info
+++ b/asu_dir_utilities/asu_dir_utilities.info
@@ -1,7 +1,7 @@
 <?php
 name = "ASU DIR Utilities"
 core = 7.x
-package = asu_dir_utilities
+package = ASU
 description = "Utilities useful for gathering data from iSearch and Solr."
 version = 7.x-1.0
 


### PR DESCRIPTION
This pull request moves the ASU DIR Utilities module from its own orphaned module group and places it alongside the ASU Local iSearch Directory module in the `ASU` package group.

![screen shot](https://cloud.githubusercontent.com/assets/133372/22304188/ae54c406-e2f3-11e6-8cb5-fd202125d798.png)
